### PR TITLE
NSGHTS-785

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -4,6 +4,39 @@ import classNames from 'classnames';
 import './button.scss';
 
 class Button extends PureComponent {
+  static defaultProps = {
+    additionalClasses: '',
+    onClick: null,
+    onMouseOver: null,
+    onMouseOut: null,
+    onMouseDown: null,
+    disabled: false,
+    type: null,
+    size: 'medium',
+    id: '',
+  };
+
+  static propTypes = {
+    additionalClasses: PropTypes.string,
+    children: PropTypes.node.isRequired,
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    onClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onMouseDown: PropTypes.func,
+    size: PropTypes.oneOf(['small', 'medium', 'full']),
+    type: PropTypes.oneOf([
+      'danger',
+      'gray',
+      'outline',
+      'outlineWhite',
+      'primary',
+      'secondary',
+      'unselected',
+    ]),
+  };
+
   render() {
     const classes = classNames(
       this.props.additionalClasses,
@@ -32,38 +65,5 @@ class Button extends PureComponent {
     );
   }
 }
-
-Button.defaultProps = {
-  additionalClasses: '',
-  onClick: null,
-  onMouseOver: null,
-  onMouseOut: null,
-  onMouseDown: null,
-  disabled: false,
-  type: null,
-  size: 'medium',
-  id: '',
-};
-
-Button.propTypes = {
-  additionalClasses: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  disabled: PropTypes.bool,
-  id: PropTypes.string,
-  onClick: PropTypes.func,
-  onMouseOut: PropTypes.func,
-  onMouseOver: PropTypes.func,
-  onMouseDown: PropTypes.func,
-  size: PropTypes.oneOf(['small', 'medium', 'full']),
-  type: PropTypes.oneOf([
-    'danger',
-    'gray',
-    'outline',
-    'outlineWhite',
-    'primary',
-    'secondary',
-    'unselected',
-  ]),
-};
 
 export default Button;

--- a/src/components/ButtonGroup/ButtonGroup.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.jsx
@@ -4,6 +4,18 @@ import classNames from 'classnames';
 import './buttonGroup.scss';
 
 class ButtonGroup extends PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    align: PropTypes.oneOf(['left', 'right', 'center', 'justified']),
+    size: PropTypes.oneOf(['medium', 'small', 'full']),
+    extraClassNames: PropTypes.string,
+  };
+  static defaultProps = {
+    align: null,
+    size: null,
+    extraClassNames: '',
+  };
+
   render() {
     const classes = classNames(
       'molecules-button-group',
@@ -20,18 +32,5 @@ class ButtonGroup extends PureComponent {
     );
   }
 }
-
-ButtonGroup.propTypes = {
-  children: PropTypes.node.isRequired,
-  align: PropTypes.oneOf(['left', 'right', 'center', 'justified']),
-  size: PropTypes.oneOf(['medium', 'small', 'full']),
-  extraClassNames: PropTypes.string,
-};
-
-ButtonGroup.defaultProps = {
-  align: null,
-  size: null,
-  extraClassNames: '',
-};
 
 export default ButtonGroup;

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -3,6 +3,19 @@ import PropTypes from 'prop-types';
 import './checkbox.scss';
 
 class Checkbox extends PureComponent {
+  static propTypes = {
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    checked: PropTypes.bool,
+    disabled: PropTypes.bool,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+    onChange: PropTypes.func,
+  };
+  static defaultProps = {
+    checked: false,
+    disabled: false,
+    onChange: null,
+  };
+
   render() {
     return (
       <div className="molecules-checkbox">
@@ -23,19 +36,5 @@ class Checkbox extends PureComponent {
     );
   }
 }
-
-Checkbox.propTypes = {
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-  onChange: PropTypes.func,
-};
-
-Checkbox.defaultProps = {
-  checked: false,
-  disabled: false,
-  onChange: null,
-};
 
 export default Checkbox;

--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -4,6 +4,22 @@ import classNames from 'classnames';
 import './link.scss';
 
 class Link extends PureComponent {
+  static propTypes = {
+    additionalClasses: PropTypes.string,
+    children: PropTypes.node.isRequired,
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    onClick: PropTypes.func,
+    type: PropTypes.oneOf(['warning', 'danger', 'secondary']),
+  };
+  static defaultProps = {
+    onClick: null,
+    disabled: false,
+    type: null,
+    additionalClasses: null,
+    id: null,
+  };
+
   render() {
     const classes = classNames('molecules-link', this.props.additionalClasses, {
       [`molecules-link--${this.props.type}`]: this.props.type,
@@ -23,22 +39,5 @@ class Link extends PureComponent {
     );
   }
 }
-
-Link.defaultProps = {
-  onClick: null,
-  disabled: false,
-  type: null,
-  additionalClasses: null,
-  id: null,
-};
-
-Link.propTypes = {
-  additionalClasses: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  disabled: PropTypes.bool,
-  id: PropTypes.string,
-  onClick: PropTypes.func,
-  type: PropTypes.oneOf(['warning', 'danger', 'secondary']),
-};
 
 export default Link;

--- a/src/components/Loader/Loader.jsx
+++ b/src/components/Loader/Loader.jsx
@@ -4,6 +4,15 @@ import classnames from 'classnames';
 import './loader.scss';
 
 class Loader extends PureComponent {
+  static propTypes = {
+    message: PropTypes.string,
+    inline: PropTypes.bool,
+  };
+  static defaultProps = {
+    inline: false,
+    message: 'Loading...',
+  };
+
   render() {
     const classes = classnames('molecules-loader', {
       'molecules-loader--inline': this.props.inline,
@@ -21,15 +30,5 @@ class Loader extends PureComponent {
     );
   }
 }
-
-Loader.defaultProps = {
-  inline: false,
-  message: 'Loading...',
-};
-
-Loader.propTypes = {
-  message: PropTypes.string,
-  inline: PropTypes.bool,
-};
 
 export default Loader;

--- a/src/components/RadioButton/RadioButton.jsx
+++ b/src/components/RadioButton/RadioButton.jsx
@@ -4,6 +4,30 @@ import classNames from 'classnames';
 import './radioButton.scss';
 
 class RadioButton extends PureComponent {
+  static propTypes = {
+    checked: PropTypes.bool,
+    disabled: PropTypes.bool,
+    error: PropTypes.bool,
+    id: PropTypes.string,
+    inline: PropTypes.bool,
+    label: PropTypes.string.isRequired,
+    name: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+    ]).isRequired,
+  };
+  static defaultProps = {
+    checked: false,
+    disabled: false,
+    error: false,
+    id: '',
+    inline: false,
+    name: 'radioButtonGroup',
+  };
+
   render() {
     const classes = classNames('molecules-radio-button', {
       'molecules-radio-button--inline': this.props.inline,
@@ -35,30 +59,5 @@ class RadioButton extends PureComponent {
     );
   }
 }
-
-RadioButton.defaultProps = {
-  checked: false,
-  disabled: false,
-  error: false,
-  id: '',
-  inline: false,
-  name: 'radioButtonGroup',
-};
-
-RadioButton.propTypes = {
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool,
-  error: PropTypes.bool,
-  id: PropTypes.string,
-  inline: PropTypes.bool,
-  label: PropTypes.string.isRequired,
-  name: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-  ]).isRequired,
-};
 
 export default RadioButton;

--- a/src/components/TypeAheadSearch/TypeAheadSearch-test.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch-test.jsx
@@ -9,6 +9,7 @@ const getProps = (overrides) => ({
   onSubmit: () => null,
   data: [],
   placeholder: '',
+  initialFilter: '',
   ...overrides,
 });
 
@@ -32,6 +33,20 @@ describe('TypeAheadSearch', () => {
   it('renders a search input', () => {
     const wrapper = shallow(<TypeAheadSearch {...getProps()} />);
     expect(wrapper.find('[data-test="search-input"]').length).toBe(1);
+  });
+  it('passes through the placeholder', () => {
+    const props = getProps({ placeholder: 'placeholder' });
+    const wrapper = shallow(<TypeAheadSearch {...props} />);
+    expect(wrapper.find('[data-test="search-input"]').props().placeholder).toBe(
+      'placeholder',
+    );
+  });
+  it('sets the value to the initialFilter if it is defined', () => {
+    const props = getProps({ initialFilter: 'initialFilter' });
+    const wrapper = shallow(<TypeAheadSearch {...props} />);
+    expect(wrapper.find('[data-test="search-input"]').props().value).toBe(
+      'initialFilter',
+    );
   });
   it('does not render the dropdown initially', () => {
     const wrapper = shallow(<TypeAheadSearch {...getProps()} />);
@@ -336,17 +351,19 @@ describe('TypeAheadSearch', () => {
 
         expect(filterData.mock.calls[0][1]).toBe('meow');
       });
-      it('calls props.onSubmit with the filtered data', () => {
+      it('calls props.onSubmit with the filtered data and selected filter', () => {
         const onSubmitSpy = jest.fn();
         const props = getProps({ onSubmit: onSubmitSpy });
         filterData.mockReturnValue([{ value: 'test', id: 42 }]);
         const wrapper = shallow(<TypeAheadSearch {...props} />);
+        wrapper.setState({ filter: 'te' });
 
         const input = wrapper.find('[data-test="search-input"]');
         input.simulate('keydown', { keyCode: 13 });
 
-        expect(onSubmitSpy.mock.calls[0][0]).toEqual([
-          { value: 'test', id: 42 },
+        expect(onSubmitSpy.mock.calls[0]).toEqual([
+          [{ value: 'test', id: 42 }],
+          'te',
         ]);
       });
     });
@@ -372,16 +389,20 @@ describe('TypeAheadSearch', () => {
 
       expect(filterData.mock.calls[0][1]).toEqual('bark');
     });
-    it('calls props.onSubmit with the filtered data', () => {
+    it('calls props.onSubmit with the filtered data and filter', () => {
       const onSubmitSpy = jest.fn();
       const props = getProps({ onSubmit: onSubmitSpy });
       filterData.mockReturnValue([{ value: 'test', id: 42 }]);
       const wrapper = shallow(<TypeAheadSearch {...props} />);
+      wrapper.setState({ filter: 'te' });
 
       const magnifyingGlass = wrapper.find('[data-test="magnifying-glass"]');
       magnifyingGlass.simulate('click');
 
-      expect(onSubmitSpy.mock.calls[0][0]).toEqual([{ value: 'test', id: 42 }]);
+      expect(onSubmitSpy.mock.calls[0]).toEqual([
+        [{ value: 'test', id: 42 }],
+        'te',
+      ]);
     });
   });
 

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -29,6 +29,10 @@ class TypeAheadSearch extends React.Component {
     activeSuggestionIndex: -1,
   };
 
+  /**
+   * Input change handler
+   * @param {object} e - event on input change
+   */
   onInputChange = (e) => {
     const filter = e.target.value;
     if (filter.trim().length > 1) {
@@ -42,6 +46,10 @@ class TypeAheadSearch extends React.Component {
     }
   };
 
+  /**
+   * On submit handler
+   * @param {string} filter - The string to filter data with
+   */
   onSubmit = (filter) => {
     this.setState({
       filter,
@@ -53,6 +61,11 @@ class TypeAheadSearch extends React.Component {
     this.props.onSubmit(filteredOptions, filter);
   };
 
+  /**
+   * Finds and emphasizes text in suggestion that matches filter
+   * @param {string[]} suggestion - The suggestion text broken into array by word
+   * @returns {jsx} - The jsx element to be displayed as suggestion text
+   */
   getSuggestionText = (suggestion) => {
     let suggestionSection = null;
     for (let wordIteration = 0; suggestionSection !== ''; wordIteration += 1) {
@@ -91,6 +104,10 @@ class TypeAheadSearch extends React.Component {
     }
   };
 
+  /**
+   * Updates the list of suggestions to match new filter
+   * @param {string} filter - filter to be used to find suggestions
+   */
   updateSuggestions = (filter) => {
     const filteredOptions = filterData(this.props.data, filter);
     const sortedOptions = sortFilteredData(filteredOptions, filter);
@@ -110,12 +127,13 @@ class TypeAheadSearch extends React.Component {
     });
   };
 
+  /**
+   * 38: up arrow - move to the previous suggestion
+   * 40: down arrow - move to the next suggestion
+   * 13: enter - submit
+   * @param {object} e - event on key down
+   */
   handleKeyDown = (e) => {
-    /*
-      38: up arrow - move to the previous suggestion
-      40: down arrow - move to the next suggestion
-      13: enter - submit
-    */
     if (this.state.suggestions.length !== 0 && e.keyCode === 38) {
       this.setState({
         activeSuggestionIndex:

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -10,7 +10,7 @@ class TypeAheadSearch extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      filter: '',
+      filter: props.initialFilter,
       suggestions: [],
       activeSuggestionIndex: -1,
     };
@@ -37,7 +37,7 @@ class TypeAheadSearch extends React.Component {
     });
     const filteredOptions = filterData(this.props.data, filter);
 
-    this.props.onSubmit(filteredOptions);
+    this.props.onSubmit(filteredOptions, filter);
   };
 
   getSuggestionText = (suggestion) => {
@@ -186,10 +186,12 @@ TypeAheadSearch.propTypes = {
       id: PropTypes.number.isRequired,
     }),
   ).isRequired,
+  initialFilter: PropTypes.string,
   placeholder: PropTypes.string,
 };
 
 TypeAheadSearch.defaultProps = {
+  initialFilter: '',
   placeholder: '',
 };
 

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -7,14 +7,11 @@ import { filterData, sortFilteredData } from './util';
 import './typeAheadSearch.scss';
 
 class TypeAheadSearch extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      filter: props.initialFilter,
-      suggestions: [],
-      activeSuggestionIndex: -1,
-    };
-  }
+  state = {
+    filter: this.props.initialFilter,
+    suggestions: [],
+    activeSuggestionIndex: -1,
+  };
 
   onInputChange = (e) => {
     const filter = e.target.value;

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -7,6 +7,22 @@ import { filterData, sortFilteredData } from './util';
 import './typeAheadSearch.scss';
 
 class TypeAheadSearch extends React.Component {
+  static propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+    data: PropTypes.arrayOf(
+      PropTypes.shape({
+        value: PropTypes.string.isRequired,
+        id: PropTypes.number.isRequired,
+      }),
+    ).isRequired,
+    initialFilter: PropTypes.string,
+    placeholder: PropTypes.string,
+  };
+  static defaultProps = {
+    initialFilter: '',
+    placeholder: '',
+  };
+
   state = {
     filter: this.props.initialFilter,
     suggestions: [],
@@ -174,22 +190,5 @@ class TypeAheadSearch extends React.Component {
     );
   }
 }
-
-TypeAheadSearch.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      id: PropTypes.number.isRequired,
-    }),
-  ).isRequired,
-  initialFilter: PropTypes.string,
-  placeholder: PropTypes.string,
-};
-
-TypeAheadSearch.defaultProps = {
-  initialFilter: '',
-  placeholder: '',
-};
 
 export default TypeAheadSearch;

--- a/src/components/TypeAheadSearch/TypeAheadSearch.stories.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.stories.jsx
@@ -86,11 +86,12 @@ const notes = {
     markdown: `
       #TypeAheadSearch
       ## Props
-      | prop name   | prop type        | required | default value | description |
-      | ----------- | ---------------- | -------- | ------------- | ----------- |
-      | onSubmit    | Function         | true     | -             | Function to be called when filter is submitted, the array of items to be displayed is passed as a prop |
-      | data        | Array of objects | true     | -             | The data to be filtered, each item in array should be formatted { value: string, id: number } |
-      | placeholder | String           | false    | ''            | Placeholder text to be displayed before input is changed |
+      | prop name     | prop type        | required | default value | description |
+      | ------------- | ---------------- | -------- | ------------- | ----------- |
+      | onSubmit      | Function         | true     | -             | Function to be called when filter is submitted, the array of items to be displayed, and the selected filter is passed as props |
+      | data          | Array of objects | true     | -             | The data to be filtered, each item in array should be formatted { value: string, id: number } |
+      | initialFilter | String           | false    | ''            | An initial filter to be displayed in the input |
+      | placeholder   | String           | false    | ''            | Placeholder text to be displayed before input is changed |
       `,
   },
 };


### PR DESCRIPTION
 Return the search filter on submit and add a optional prop to set an initial filter on render.

This allows the component using the `<TypeAheadSearch/>` to remember the last searched filter. Below is an example use case of this on the adherence page:

![Sep-05-2019 11-28-30](https://user-images.githubusercontent.com/22682031/64364556-5653f200-cfd0-11e9-85c1-4497046eeaf3.gif)

Checkout the code for the above implementation [here](https://github.com/Hireology/app/blob/f59cdc13b77e2ffe418586b49c9b7598533551bd/app/assets/javascripts/react/insights/routes/Adherence/components/SearchFilter/SearchFilter.jsx)