### PR TITLE
Fix bug where dropdown pops up after the user has clicked submit

### DIFF
--- a/src/components/TypeAheadSearch/TypeAheadSearch-test.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch-test.jsx
@@ -302,7 +302,7 @@ describe('TypeAheadSearch', () => {
       setTimeout(() => {
         expect(onChangeSpy.mock.calls.length).toBe(1);
         done();
-      }, 1000);
+      }, 500);
     });
   });
 
@@ -439,7 +439,7 @@ describe('TypeAheadSearch', () => {
       setTimeout(() => {
         expect(onChangeSpy.mock.calls.length).toBe(0);
         done();
-      }, 1000);
+      }, 500);
     });
 
     it('does not change anything for other keys', () => {

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -33,6 +33,7 @@ class TypeAheadSearch extends React.Component {
     filter: this.props.initialFilter,
     suggestions: [],
     activeSuggestionIndex: -1,
+    shouldCallOnChange: true,
   };
 
   /**
@@ -74,7 +75,23 @@ class TypeAheadSearch extends React.Component {
 
       this.props.onSubmit(filteredOptions, filter);
     } else {
+      this.setState({ shouldCallOnChange: false });
       this.props.onSubmit(filter);
+    }
+  };
+
+  /**
+   * On change handler
+   * @param {string} filter - The string to filter data with
+   * Only call onChange if submit has not been recently clicked
+   * to avoid a dropdown being shown after the user has already
+   * submitted the data
+   */
+  onChangeHandler = (filter) => {
+    if (this.state.shouldCallOnChange) {
+      this.props.onChange(filter);
+    } else {
+      this.setState({ shouldCallOnChange: true });
     }
   };
 
@@ -124,7 +141,7 @@ class TypeAheadSearch extends React.Component {
     return <span data-test="suggestion-text">{suggestion}</span>;
   };
 
-  delayedOnChange = debounce(this.props.onChange, 1000);
+  delayedOnChange = debounce(this.onChangeHandler, 1000);
 
   /**
    * Updates the list of suggestions to match new filter

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -141,7 +141,7 @@ class TypeAheadSearch extends React.Component {
     return <span data-test="suggestion-text">{suggestion}</span>;
   };
 
-  delayedOnChange = debounce(this.onChangeHandler, 1000);
+  delayedOnChange = debounce(this.onChangeHandler, 500);
 
   /**
    * Updates the list of suggestions to match new filter

--- a/src/components/TypeAheadSearch/TypeAheadSearch.jsx
+++ b/src/components/TypeAheadSearch/TypeAheadSearch.jsx
@@ -38,9 +38,11 @@ class TypeAheadSearch extends React.Component {
 
   /**
    * Input change handler
-   * @param {object} e - event on input change
+   *
    * If we are handling filtering, update the suggestions
    * If we are not handling filtering, callback to parent component
+   *
+   * @param {object} e - event on input change
    */
   onInputChange = (e) => {
     const filter = e.target.value;
@@ -61,9 +63,11 @@ class TypeAheadSearch extends React.Component {
 
   /**
    * On submit handler
-   * @param {string} filter - The string to filter data with
+   *
    * If we are handling filtering, callback with the filtered data and filter string,
    * If we are not handling filtering, callback with the filter string
+   *
+   * @param {string} filter - The string to filter data with
    */
   onSubmit = (filter) => {
     this.setState({ filter, activeSuggestionIndex: -1 });
@@ -82,10 +86,12 @@ class TypeAheadSearch extends React.Component {
 
   /**
    * On change handler
-   * @param {string} filter - The string to filter data with
+   *
    * Only call onChange if submit has not been recently clicked
    * to avoid a dropdown being shown after the user has already
    * submitted the data
+   *
+   * @param {string} filter - The string to filter data with
    */
   onChangeHandler = (filter) => {
     if (this.state.shouldCallOnChange) {
@@ -97,10 +103,12 @@ class TypeAheadSearch extends React.Component {
 
   /**
    * Finds and emphasizes text in suggestion that matches filter
-   * @param {string[]} suggestion - The suggestion text broken into array by word
-   * @returns {jsx} - The jsx element to be displayed as suggestion text
+   *
    * If no match is found, just return the string. This should only be true if the parent
    * component is passing suggestions and hasn't caught up to the input yet
+   *
+   * @param {string[]} suggestion - The suggestion text broken into array by word
+   * @returns {jsx} - The jsx element to be displayed as suggestion text
    */
   getSuggestionText = (suggestion) => {
     let suggestionSection = null;
@@ -145,6 +153,7 @@ class TypeAheadSearch extends React.Component {
 
   /**
    * Updates the list of suggestions to match new filter
+   *
    * @param {string} filter - filter to be used to find suggestions
    */
   updateSuggestions = (filter) => {
@@ -169,6 +178,7 @@ class TypeAheadSearch extends React.Component {
    * 38: up arrow - move to the previous suggestion
    * 40: down arrow - move to the next suggestion
    * 13: enter - submit
+   *
    * @param {object} e - event on key down
    */
   handleKeyDown = (e) => {


### PR DESCRIPTION
There was an issue with the type ahead search with custom filtering. If the user typed quickly and clicked submit, the data would filter and *then* a dropdown would show up. This fix stops the dropdown from showing after a user has clicked submit if the input hasn't changed.

Before:
![typeAheadBug](https://user-images.githubusercontent.com/22682031/69065150-8100f480-09dc-11ea-98e5-447e0961c17c.gif)

After:
![typeAheadFix](https://user-images.githubusercontent.com/22682031/69065166-8bbb8980-09dc-11ea-83ad-2378e40ff541.gif)
