### PR TITLE
MINHEIGHT Use min-height insteade of height so we can scroll the modal

### DIFF
--- a/src/components/Modal/modal.scss
+++ b/src/components/Modal/modal.scss
@@ -44,7 +44,7 @@
       justify-content: center;
       padding: 0em;
       border-radius: 0px;
-      height: 100%;
+      min-height: 100%;
       width: 100%;
       top: 0;
       right: 0;


### PR DESCRIPTION
Before, if the content was taller then the screen when you scrolled down the content would render on the backdrop:
<img width="398" alt="Screen Shot 2020-06-05 at 1 44 05 PM" src="https://user-images.githubusercontent.com/22682031/83916595-b0860d00-a732-11ea-955a-dc9a1af8b2e0.png">

After:
<img width="402" alt="Screen Shot 2020-06-05 at 1 44 15 PM" src="https://user-images.githubusercontent.com/22682031/83916609-b4199400-a732-11ea-8669-0912b54c4e78.png">
