### PR TITLE
replace throttle button behavior with debounce button behavior

### DIFF
--- a/src/components/Button/Button-test.jsx
+++ b/src/components/Button/Button-test.jsx
@@ -81,12 +81,17 @@ describe('button', () => {
     expect(onMouseDownSpy.mock.calls.length).toBe(1);
   });
 
-  it('throttles clicks', () => {
+  it('only allows a single click when button is clicked more than once in a second', (done) => {
     const onClickSpy = jest.fn();
     const props = getProps({ onClick: onClickSpy });
     const wrapper = shallow(<Button {...props}>Button</Button>);
     wrapper.simulate('click');
-    wrapper.simulate('click');
-    expect(onClickSpy.mock.calls.length).toBe(1);
+    setTimeout(() => {
+      wrapper.simulate('click');
+    }, 500);
+    setTimeout(() => {
+      expect(onClickSpy.mock.calls.length).toBe(1);
+      done();
+    }, 1200);
   });
 });

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import throttle from 'lodash/throttle';
+import debounce from 'lodash/debounce';
 
 class Button extends PureComponent {
   static defaultProps = {
@@ -39,7 +39,10 @@ class Button extends PureComponent {
 
   constructor(props) {
     super(props);
-    this.throttledClick = throttle(this.handleClick, 1000);
+    this.debouncedClick = debounce(this.handleClick, 1000, {
+      leading: true,
+      trailing: false,
+    });
   }
 
   handleClick = (event) => {
@@ -63,7 +66,7 @@ class Button extends PureComponent {
       <button
         id={this.props.id}
         disabled={this.props.disabled}
-        onClick={this.throttledClick}
+        onClick={this.debouncedClick}
         onMouseOver={this.props.onMouseOver}
         onMouseOut={this.props.onMouseOut}
         onMouseDown={this.props.onMouseDown}


### PR DESCRIPTION
I always get `throttle` and `debounce` confused.
`throttle` will call a click handler a single time when multiple clicks are received after the first one.
`debounce` will discard additional clicks after the initial click when `leading` is true and `trailing` is false.
The button test was also updated to test for the correct behavior. It fails on `throttle` but passes on the updated `debounce` behavior.
