### PR TITLE
ATSWEB-420 

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -51,6 +51,13 @@ class Modal extends Component {
     }
   }
 
+  componentDidUpdate(oldProps) {
+    if (oldProps.isOpen !== this.props.isOpen) {
+      // Prevent the body of the page from scrolling if the modal is open
+      document.body.style.overflowY = this.props.isOpen ? 'hidden' : 'unset';
+    }
+  }
+
   componentWillUnmount() {
     if (this.props.closeOnEsc) {
       window.removeEventListener('keydown', this.onEscKeyDown, false);


### PR DESCRIPTION
Epic: [ATSWEB-418](https://hireology.atlassian.net/browse/ATSWEB-418)
Story: [ATSWEB-420](https://hireology.atlassian.net/browse/ATSWEB-420)

TLDR: It's confusing to users when there are two scrollbars when a modal is open. We need to hide the main scrollbar for them when they're looking at a modal.

To see the double scroll bar as it exists today go to our [storybook page for the advanced modal](https://hireology-storybook.netlify.app/?path=/story/modal--advanced) and pull the notes up high enough until there is a regular scrollbar on the page. Then open the modal and see that there are now two scrollbars.

To see the fix do the same thing in this PR's [deploy preview](https://deploy-preview-63--hireology-storybook.netlify.app/?path=/story/modal--advanced).