### PR TITLE
PEERDEPENDENCIES

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
     "test-coverage": "NODE_ENV=test jest --coverage"
   },
   "dependencies": {
-    "react-onclickoutside": "6.7.0",
     "react-popper": "^1.3.6",
     "react-portal": "4.2.1",
     "react-transition-group": "^1.2.1"
   },
   "peerDependencies": {
-    "react": "15.6.2",
-    "react-dom": "15.6.2",
-    "prop-types": "^15.7.2",
+    "react": ">=15.6.2",
+    "react-dom": ">=15.6.2",
+    "react-onclickoutside": ">=6.7.0",
+    "prop-types": "15.7.2",
     "classnames": "2.2.5",
     "lodash": "^4.17.15"
   },
@@ -70,6 +70,7 @@
     "prop-types": "^15.7.2",
     "react": "15.6.2",
     "react-dom": "15.6.2",
+    "react-onclickoutside": "6.7.0",
     "react-test-renderer": "15.6.2",
     "rollup": "^1.16.7",
     "rollup-plugin-babel": "^4.3.3",


### PR DESCRIPTION
Allow any version of react greater than or equal to the version in our monolith.

The code in molecules is written using React 15.6.2 but it is also valid in React 17. Since React is a peer dependency for molecules, we should be able to import it into a webapp that uses either version. This way we will be able to share components between our legacy code in the monolith and our newer code for Inbox.

I don't think doing this is exactly best practice, so if anyone has concerns or a better idea how we can handle sharing these components please let me know. I plan on doing a release candidate of these changes to make sure it works as expected before doing a regular release.