### PR TITLE
FE-339 Updated modal code so that it does not close on clicking outside the modal by default

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -38,7 +38,7 @@ class Modal extends Component {
   static defaultProps = {
     aria: 'Modal Dialog',
     closeOnEsc: true,
-    closeOnOverlayClick: true,
+    closeOnOverlayClick: false,
     isLoadingContent: false,
     isOpen: false,
     showOverlay: true,


### PR DESCRIPTION
This fixes one part of the issues outlined in FE-339 by updating the molecules modal default behavior. This should prevent any modals built in the app using molecules modals from closing when the user clicks outside of the modal.